### PR TITLE
Add music cover video preview generation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,7 @@ Before you submit your pull request, please review the following checklist:
 - [ ] I have made corresponding changes to the documentation.
 - [ ] My changes generate no new warnings.
 - [ ] I have updated the Dockerfile with any new dependencies (if applicable).
+- [ ] I have added these changes to the latest changelog for an upcoming release.
 
 # Additional context
 Add any other context about the pull request here.

--- a/.github/workflows/release-creation.yaml
+++ b/.github/workflows/release-creation.yaml
@@ -1,4 +1,5 @@
-name: Release Created
+name: Update Changelog Release Notes
+run-name: Update Release Notes (${{ github.ref_name }})
 
 on:
   release:

--- a/.github/workflows/release-creation.yaml
+++ b/.github/workflows/release-creation.yaml
@@ -1,0 +1,34 @@
+name: Release Created
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  update-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate Changelog
+        id: changelog
+        uses: infocus7/changelog-files-action@v1.0.0
+        with:
+          changelog-directory: 'changelogs'
+          release-tag-name: ${{ github.ref_name }}
+      - name: Download Changelog # This is needed because the action outputs the changelog to an artifact (file).
+        uses: actions/download-artifact@v2
+        with:
+          name: changelog
+      - name: Update Release Notes
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_NAME: ${{ github.repository }}
+          RELEASE_ID: ${{ github.event.release.id }}
+        run: |
+          changelog_content=$(jq -Rs . < changelog_output.md) # Convert the changelog to a JSON string so we can send it.
+          curl -L -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$REPO_NAME/releases/$RELEASE_ID" \
+            -d "{\"body\": $changelog_content}"

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Published
 
 on:
   release:

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -1,4 +1,5 @@
-name: Release Published
+name: Publish Docker Images
+run-name: Publish To Docker (${{ github.ref_name }})
 
 on:
   release:

--- a/changelogs/v1.0.0-beta4
+++ b/changelogs/v1.0.0-beta4
@@ -1,0 +1,4 @@
+enhancement:
+  - Add support for video preview generation when creating a music cover video.
+ci:
+  - Add changelog generation automation.

--- a/ui/music/interface.py
+++ b/ui/music/interface.py
@@ -3,7 +3,7 @@ Tbe interface for the music section of the UI. This is the main piece where we d
 """
 import gradio as gr
 import utils.gradio as gru
-from ui.music.utils import generate_cover_image, process, create_music_video
+from ui.music.utils import generate_cover_image, process, create_music_video, create_music_video_preview
 import processing.video as video_processing
 import processing.image as image_processing
 import ui.components.openai as openai_components
@@ -149,9 +149,9 @@ def render_music_video_creation() -> gr.Image:
                         with gr.Row():
                             audio_visualizer_amount = dataclasses.RowColGradioComponents(
                                 row=gr.Number(value=90, label="Number of Rows", minimum=1,
-                                                                  maximum=100),
+                                              maximum=100),
                                 col=gr.Number(value=65, label="Number of Columns", minimum=1,
-                                                                     maximum=100)
+                                              maximum=100)
                             )
                         with gr.Row():
                             audio_visualizer_dot_size = dataclasses.MinMaxGradioComponents(
@@ -170,12 +170,55 @@ def render_music_video_creation() -> gr.Image:
                                                                    "transparent, leave this unchecked.")
             gru.bind_checkbox_to_visibility(generate_audio_visualizer_button, audio_visualizer_group)
 
+    with gr.Group():
+        with gr.Row():
+            create_preview_video_button = gr.Button("Create Preview", variant="secondary")
+            preview_seconds = gr.Number(value=5, label="Preview Seconds", minimum=1, maximum=10)
+
     create_video_button = gr.Button("Create Music Video", variant="primary")
 
     gr.Markdown("## Output")
     with gr.Group():
         video_data = video_processing.render_video_output()
 
+    create_preview_video_button.click(create_music_video_preview, inputs=[cover_image, audio_filepath, fps,
+                                                                          preview_seconds, artist_name,
+                                                                          artist_font_display.font.family,
+                                                                          artist_font_display.font.style,
+                                                                          artist_font_display.font.size,
+                                                                          artist_font_display.font.color,
+                                                                          artist_font_display.font.opacity,
+                                                                          artist_font_display.drop_shadow.enabled,
+                                                                          artist_font_display.drop_shadow.color,
+                                                                          artist_font_display.drop_shadow.opacity,
+                                                                          artist_font_display.drop_shadow.radius,
+                                                                          artist_font_display.background.enabled,
+                                                                          artist_font_display.background.color,
+                                                                          artist_font_display.background.opacity,
+                                                                          song_title, song_font_display.font.family,
+                                                                          song_font_display.font.style,
+                                                                          song_font_display.font.size,
+                                                                          song_font_display.font.color,
+                                                                          song_font_display.font.opacity,
+                                                                          song_font_display.drop_shadow.enabled,
+                                                                          song_font_display.drop_shadow.color,
+                                                                          song_font_display.drop_shadow.opacity,
+                                                                          song_font_display.drop_shadow.radius,
+                                                                          song_font_display.background.enabled,
+                                                                          song_font_display.background.color,
+                                                                          song_font_display.background.opacity,
+                                                                          background_color_opacity.color,
+                                                                          background_color_opacity.opacity,
+                                                                          generate_audio_visualizer_button,
+                                                                          audio_visualizer_color_opacity.color,
+                                                                          audio_visualizer_color_opacity.opacity,
+                                                                          audio_visualizer_drawing,
+                                                                          visualizer_overlay_checkbox,
+                                                                          audio_visualizer_amount.row,
+                                                                          audio_visualizer_amount.col,
+                                                                          audio_visualizer_dot_size.min,
+                                                                          audio_visualizer_dot_size.max],
+                                      outputs=[video_data.video])
     create_video_button.click(create_music_video, inputs=[cover_image, audio_filepath, fps, artist_name,
                                                           artist_font_display.font.family,
                                                           artist_font_display.font.style, artist_font_display.font.size,

--- a/ui/music/interface.py
+++ b/ui/music/interface.py
@@ -173,7 +173,7 @@ def render_music_video_creation() -> gr.Image:
     with gr.Group():
         with gr.Row():
             create_preview_video_button = gr.Button("Create Preview", variant="secondary")
-            preview_seconds = gr.Number(value=5, label="Preview Seconds", minimum=1, maximum=10)
+            preview_seconds = gr.Number(value=5, label="Preview Duration (s)", minimum=1, maximum=10)
 
     create_video_button = gr.Button("Create Music Video", variant="primary")
 


### PR DESCRIPTION
# Description
Adds preview generation so you don't have to generate the complete video.

Fixes #32 

# Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tried locally with different lengths, with the edge-case - where the duration > audio.length - working as expected. 

# Checklist:
Before you submit your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have updated the Dockerfile with any new dependencies (if applicable).
- [ ] I have added these changes to the latest changelog for an upcoming release.

# Additional context
Add any other context about the pull request here.
